### PR TITLE
Fixes log reopening.

### DIFF
--- a/tail_test.go
+++ b/tail_test.go
@@ -343,7 +343,7 @@ func reOpen(t *testing.T, poll bool) {
 		"test.txt",
 		Config{Follow: true, ReOpen: true, Poll: poll})
 	content := []string{"hello", "world", "more", "data", "endofworld"}
-	go tailTest.ReadLines(tail, content)
+	go tailTest.VerifyTailOutput(tail, content, false)
 
 	// deletion must trigger reopen
 	<-time.After(delay)
@@ -366,7 +366,7 @@ func reOpen(t *testing.T, poll bool) {
 	// Do not bother with stopping as it could kill the tomb during
 	// the reading of data written above. Timings can vary based on
 	// test environment.
-	tail.Cleanup()
+	tailTest.Cleanup(tail, false)
 }
 
 func reSeek(t *testing.T, poll bool) {

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -155,6 +155,8 @@ func (shared *InotifyTracker) addWatch(winfo *watchInfo) error {
 
 	if shared.chans[winfo.fname] == nil {
 		shared.chans[winfo.fname] = make(chan fsnotify.Event)
+	}
+	if shared.done[winfo.fname] == nil {
 		shared.done[winfo.fname] = make(chan bool)
 	}
 


### PR DESCRIPTION
This fixes a situation when logs are rotated via movement.
1. A log is rotated.
2. The library sees that, closes the watch on the file, and sets up a directory watch for the file to appear.
3. New log file is created.
4. The library sees the file created, and removes the directory watch
5. The library creates a watch on the file itself now that the file is present.

In the current code, (4) [cleans up](https://github.com/vsco/tail/blob/33107f39d57efc81a65abac168f12804e2fe4e19/watch/inotify_tracker.go#L106) the `done` channel but then removes the directory watch and [exits](https://github.com/vsco/tail/blob/33107f39d57efc81a65abac168f12804e2fe4e19/watch/inotify_tracker.go#L129) without instructing the `InotifyTracker::run` to complete the cleanup via the `removeWatch` method. This results in the event channel for the file not being cleaned up. It's not a problem in itself, but then in (5), `addWatch` [uses](https://github.com/vsco/tail/blob/33107f39d57efc81a65abac168f12804e2fe4e19/watch/inotify_tracker.go#L156) the presence of the event channel to decide whether initialize both events and `done` channel. As the event channel is still present, the `done` channel is not initialized. Subsequently, absence of the `done` channel [prevents](https://github.com/vsco/tail/blob/33107f39d57efc81a65abac168f12804e2fe4e19/watch/inotify_tracker.go#L219) `sendEvents` from forwarding fsnotify events to clients.

This change makes a separate check for presence of the of the `done` channel in order to initialize it. The changes in the test introduce stricter checks: without them the test hangs and is subsequently terminated as lines are not being delivered to the reader.