### PR TITLE
Fix log reopen with inotify

### DIFF
--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -99,7 +99,7 @@ func (fw *InotifyFileWatcher) ChangeEvents(t *tomb.Tomb, pos int64) (*FileChange
 			//With an open fd, unlink(fd) - inotify returns IN_ATTRIB (==fsnotify.Chmod)
 			case evt.Op&fsnotify.Chmod == fsnotify.Chmod:
 				if _, err := os.Stat(fw.Filename); err != nil {
-					if ! os.IsNotExist(err) {
+					if !os.IsNotExist(err) {
 						return
 					}
 				}

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -108,28 +108,10 @@ func remove(winfo *watchInfo) error {
 		delete(shared.done, winfo.fname)
 		close(done)
 	}
-
-	fname := winfo.fname
-	if winfo.isCreate() {
-		// Watch for new files to be created in the parent directory.
-		fname = filepath.Dir(fname)
-	}
-	shared.watchNums[fname]--
-	watchNum := shared.watchNums[fname]
-	if watchNum == 0 {
-		delete(shared.watchNums, fname)
-	}
 	shared.mux.Unlock()
 
-	// If we were the last ones to watch this file, unsubscribe from inotify.
-	// This needs to happen after releasing the lock because fsnotify waits
-	// synchronously for the kernel to acknowledge the removal of the watch
-	// for this file, which causes us to deadlock if we still held the lock.
-	if watchNum == 0 {
-		return shared.watcher.Remove(fname)
-	}
 	shared.remove <- winfo
-	return nil
+	return <-shared.error
 }
 
 // Events returns a channel to which FileEvents corresponding to the input filename
@@ -166,47 +148,48 @@ func (shared *InotifyTracker) addWatch(winfo *watchInfo) error {
 		fname = filepath.Dir(fname)
 	}
 
+	var err error
 	// already in inotify watch
-	if shared.watchNums[fname] > 0 {
-		shared.watchNums[fname]++
-		if winfo.isCreate() {
-			shared.watchNums[winfo.fname]++
-		}
-		return nil
+	if shared.watchNums[fname] == 0 {
+		err = shared.watcher.Add(fname)
 	}
-
-	err := shared.watcher.Add(fname)
-	if err == nil {
-		shared.watchNums[fname]++
-		if winfo.isCreate() {
-			shared.watchNums[winfo.fname]++
-		}
-	}
+	shared.watchNums[fname]++
 	return err
 }
 
 // removeWatch calls fsnotify.RemoveWatch for the input filename and closes the
 // corresponding events channel.
-func (shared *InotifyTracker) removeWatch(winfo *watchInfo) {
+func (shared *InotifyTracker) removeWatch(winfo *watchInfo) error {
 	shared.mux.Lock()
-	defer shared.mux.Unlock()
 
 	ch := shared.chans[winfo.fname]
-	if ch == nil {
-		return
+	if ch != nil {
+		delete(shared.chans, winfo.fname)
+		close(ch)
 	}
 
-	delete(shared.chans, winfo.fname)
-	close(ch)
+	fname := winfo.fname
+	if winfo.isCreate() {
+		// Watch for new files to be created in the parent directory.
+		fname = filepath.Dir(fname)
+	}
+	shared.watchNums[fname]--
+	watchNum := shared.watchNums[fname]
+	if watchNum == 0 {
+		delete(shared.watchNums, fname)
+	}
+	shared.mux.Unlock()
 
-	if !winfo.isCreate() {
-		return
+	var err error
+	// If we were the last ones to watch this file, unsubscribe from inotify.
+	// This needs to happen after releasing the lock because fsnotify waits
+	// synchronously for the kernel to acknowledge the removal of the watch
+	// for this file, which causes us to deadlock if we still held the lock.
+	if watchNum == 0 {
+		err = shared.watcher.Remove(fname)
 	}
 
-	shared.watchNums[winfo.fname]--
-	if shared.watchNums[winfo.fname] == 0 {
-		delete(shared.watchNums, winfo.fname)
-	}
+	return err
 }
 
 // sendEvent sends the input event to the appropriate Tail.
@@ -241,7 +224,7 @@ func (shared *InotifyTracker) run() {
 			shared.error <- shared.addWatch(winfo)
 
 		case winfo := <-shared.remove:
-			shared.removeWatch(winfo)
+			shared.error <- shared.removeWatch(winfo)
 
 		case event, open := <-shared.watcher.Events:
 			if !open {

--- a/watch/inotify_tracker.go
+++ b/watch/inotify_tracker.go
@@ -153,7 +153,9 @@ func (shared *InotifyTracker) addWatch(winfo *watchInfo) error {
 	if shared.watchNums[fname] == 0 {
 		err = shared.watcher.Add(fname)
 	}
-	shared.watchNums[fname]++
+	if err == nil {
+		shared.watchNums[fname]++
+	}
 	return err
 }
 


### PR DESCRIPTION
@negator It turns out that there was another problem in remove: when called from `RemoveWatchCreate` it was decrementing the watch counter for the parent of the filename tracked, then removing the watch and bailing out. But the corresponding `WatchCreate` was incrementing counters for both tracked filename and its parent. Thus, the count for the filename was leaked. The following `Create` call would find the count for the filename already at 1 and assume the watch for the filename itself is already there.

This change does a couple of things:
 1. It moves most of the `remove` functionality into `removeWatch` running in a `run` runloop which makes the code more symmetric and easier to reason about. The `done` channel deletion is still done synchronously in order to stop delivery of notifications as soon as `RemoveWatch` or `RemoveWatchCreate` are called.
2. It only tracks watch counter of the actual filename watched via fsnotify (i.e., the file itself for `Watch` call and the files's directory for `WatchCreate` as the sole purpose of those counters is to save of `fsnotify` watches - the event delivery is controlled through presence of `shared.chans` and `shared.done`.
 3. The first two changes make easier to track changes to watch counts and have `RemoveWatchXX` calls precisely reverse changes made by `WatchXX`.